### PR TITLE
LRQA-37984, LRQA-38418 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -223,27 +223,25 @@
 	</command>
 
 	<command name="openLocaleURL" >
-		<execute macro="Navigator#getCurrentURL">
-			<return from="currentURL" name="adminEditURL" />
-		</execute>
+		<var method="TestPropsUtil#get('portal.url')" name="currentURL" />
 
-		<var method="StringUtil#extractFirst('${adminEditURL}','/group/')" name="currentlocaleURL" />
+		<var method="StringUtil#extractFirst('${currentURL}','/group/')" name="currentlocaleURL" />
 
 		<if>
 			<not>
 				<equals arg1="${localeURL}" arg2="${currentlocaleURL}" />
 			</not>
 			<then>
-				<var method="StringUtil#extractLast('${adminEditURL}','/group/')" name="currentExtraURL" />
+				<var method="StringUtil#extractLast('${currentURL}','/group/')" name="currentExtraURL" />
 
-				<var name="maliciousURL">
+				<var name="reconstructedURL">
 					<![CDATA[
 						${localeURL}/group/${currentExtraURL}
 					]]>
 				</var>
 
 				<execute macro="Navigator#openSpecificURL">
-					<var name="url" value="${maliciousURL}" />
+					<var name="url" value="${reconstructedURL}" />
 				</execute>
 			</then>
 		</if>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -223,8 +223,6 @@
 	</command>
 
 	<command name="openLocaleURL" >
-		<var name="localeURL" value="${localeURL}" />
-
 		<execute macro="Navigator#getCurrentURL">
 			<return from="currentURL" name="adminEditURL" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -222,7 +222,7 @@
 		</if>
 	</command>
 
-	<command name="openLocaleURL" >
+	<command name="ensureLocaleURL" >
 		<var method="TestPropsUtil#get('portal.url')" name="currentURL" />
 
 		<var method="StringUtil#extractFirst('${currentURL}','/group/')" name="currentlocaleURL" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -222,6 +222,35 @@
 		</if>
 	</command>
 
+	<command name="openLocaleURL" >
+		<var name="localeURL" value="${localeURL}" />
+
+		<execute macro="Navigator#getCurrentURL">
+			<return from="currentURL" name="adminEditURL" />
+		</execute>
+
+		<var method="StringUtil#extractFirst('${adminEditURL}','/group/')" name="currentlocaleURL" />
+
+		<if>
+			<not>
+				<equals arg1="${localeURL}" arg2="${currentlocaleURL}" />
+			</not>
+			<then>
+				<var method="StringUtil#extractLast('${adminEditURL}','/group/')" name="currentExtraURL" />
+
+				<var name="maliciousURL">
+					<![CDATA[
+						${localeURL}/group/${currentExtraURL}
+					]]>
+				</var>
+
+				<execute macro="Navigator#openSpecificURL">
+					<var name="url" value="${maliciousURL}" />
+				</execute>
+			</then>
+		</if>
+	</command>
+
 	<command name="openNodePort">
 		<execute function="Open" locator1="http://localhost:${nodePort}" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Navigator.macro
@@ -35,6 +35,31 @@
 		<execute function="Close#closeWindow" />
 	</command>
 
+	<command name="ensureLocaleURL" >
+		<var method="TestPropsUtil#get('portal.url')" name="currentURL" />
+
+		<var method="StringUtil#extractFirst('${currentURL}','/group/')" name="currentlocaleURL" />
+
+		<if>
+			<not>
+				<equals arg1="${localeURL}" arg2="${currentlocaleURL}" />
+			</not>
+			<then>
+				<var method="StringUtil#extractLast('${currentURL}','/group/')" name="currentExtraURL" />
+
+				<var name="reconstructedURL">
+					<![CDATA[
+						${localeURL}/group/${currentExtraURL}
+					]]>
+				</var>
+
+				<execute macro="Navigator#openSpecificURL">
+					<var name="url" value="${reconstructedURL}" />
+				</execute>
+			</then>
+		</if>
+	</command>
+
 	<command name="getCurrentURL" returns="currentURL">
 		<var method="selenium#getLocation()" name="currentURL" />
 
@@ -219,31 +244,6 @@
 			<else>
 				<execute function="AssertClick" locator1="Home#PAGE" value1="${pageName}" />
 			</else>
-		</if>
-	</command>
-
-	<command name="ensureLocaleURL" >
-		<var method="TestPropsUtil#get('portal.url')" name="currentURL" />
-
-		<var method="StringUtil#extractFirst('${currentURL}','/group/')" name="currentlocaleURL" />
-
-		<if>
-			<not>
-				<equals arg1="${localeURL}" arg2="${currentlocaleURL}" />
-			</not>
-			<then>
-				<var method="StringUtil#extractLast('${currentURL}','/group/')" name="currentExtraURL" />
-
-				<var name="reconstructedURL">
-					<![CDATA[
-						${localeURL}/group/${currentExtraURL}
-					]]>
-				</var>
-
-				<execute macro="Navigator#openSpecificURL">
-					<var name="url" value="${reconstructedURL}" />
-				</execute>
-			</then>
 		</if>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -564,8 +564,7 @@
 		<execute macro="User#acceptEndUserLicenseAgreement" />
 
 		<execute macro="User#resetPassword">
-			<var name="resetPassword" value="passwordreset" />
-			<var name="syntaxCheckingEnabled" value="true" />
+			<var name="setupWizardEnabled" value="true" />
 		</execute>
 
 		<execute macro="User#answerPasswordReminder" />
@@ -575,7 +574,7 @@
 		<execute macro="User#logoutPG" />
 
 		<execute macro="User#loginPG">
-			<var name="password" value="passwordreset" />
+			<var name="password" value="test2" />
 			<var name="userEmailAddress" value="test@liferay.com" />
 		</execute>
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -550,6 +550,36 @@
 		<execute function="Pause" locator1="10000" />
 	</command>
 
+	<command name="resetTestUserPassword">
+		<execute macro="SetupWizard#finishConfigurationPG" />
+
+		<execute macro="Portlet#shutdownServer" />
+
+		<execute macro="Portlet#startServer">
+			<var name="deleteLiferayHome" value="false" />
+		</execute>
+
+		<execute macro="Navigator#openURL" />
+
+		<execute macro="User#acceptEndUserLicenseAgreement" />
+
+		<execute macro="User#resetPassword">
+			<var name="resetPassword" value="passwordreset" />
+			<var name="syntaxCheckingEnabled" value="true" />
+		</execute>
+
+		<execute macro="User#answerPasswordReminder" />
+
+		<execute function="AssertElementPresent" locator1="UserBar#USER_AVATAR_IMAGE" />
+
+		<execute macro="User#logoutPG" />
+
+		<execute macro="User#loginPG">
+			<var name="password" value="passwordreset" />
+			<var name="userEmailAddress" value="test@liferay.com" />
+		</execute>
+	</command>
+
 	<command name="searchForAssetsAfterUpgrade">
 		<execute macro="Navigator#openURL" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectStructure.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/dynamicdatamapping/DDMSelectStructure.path
@@ -66,6 +66,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>DDM_STRUCTURE_TABLE_NAME_2</td>
+	<td>xpath=(//a[contains(text(),'${key_ddlDataDefinitionName}')])[2]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>DDM_STRUCTURE_TABLE_NAME_LINK</td>
 	<td>//div[contains(@id,'ddmStructuresSearchContainer')]//tr[contains(.,'${key_ddlDataDefinitionName}')]/td[count(//th[contains(.,'Name')]//preceding-sibling::th) + 1]//a[1]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
@@ -1,0 +1,16 @@
+<definition component-name="portal-upgrades">
+	<property name="portal.release" value="true" />
+	<property name="portal.upstream" value="true" />
+	<property name="ignore.errors" value="Plugin security management is not enabled. Enable a security manager, then restart." />
+	<property name="testray.main.component.name" value="Upgrades Foundation" />
+
+	<command name="ResetTestUserPasswordAfterUpgrade625" priority="5">
+		<description message="This is a use case for LPS-73277." />
+
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="6.2.5" />
+		<property name="setup.wizard.enabled" value="true" />
+
+		<execute macro="Upgrade#resetTestUserPassword" />
+	</command>
+</definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
@@ -4,6 +4,16 @@
 	<property name="ignore.errors" value="Plugin security management is not enabled. Enable a security manager, then restart." />
 	<property name="testray.main.component.name" value="Upgrades Foundation" />
 
+	<command name="ResetTestUserPasswordAfterUpgrade621015" priority="5">
+		<description message="This is a use case for LPS-73277." />
+
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="6.2.10.15" />
+		<property name="setup.wizard.enabled" value="true" />
+
+		<execute macro="Upgrade#resetTestUserPassword" />
+	</command>
+
 	<command name="ResetTestUserPasswordAfterUpgrade625" priority="5">
 		<description message="This is a use case for LPS-73277." />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
@@ -212,8 +212,10 @@
 
 		<property name="test.name.skip.portal.instance" value="CPWebcontent#AddStructureViaLocaleURL" />
 
+		<var method="TestPropsUtil#get('portal.url')" name="portalURL" />
+
 		<execute macro="Navigator#openSpecificURL">
-			<var name="url" value="http://localhost:8080/en/" />
+			<var name="url" value="${portalURL}/en/" />
 		</execute>
 
 		<execute macro="ProductMenu#gotoPortlet">
@@ -229,7 +231,7 @@
 		<execute function="Pause" locator1="3000" />
 
 		<execute macro="Navigator#openLocaleURL">
-			<var name="localeURL" value="http://localhost:8080/en" />
+			<var name="localeURL" value="${portalURL}/en" />
 		</execute>
 
 		<execute macro="WebContentStructures#addName">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
@@ -210,7 +210,7 @@
 	<command name="AddStructureViaLocaleURL" priority="4">
 		<description message="This is a use case for LPS-77387." />
 
-		<property name="test.name.skip.portal.instance" value="CPWebcontent#AddStructureInEnLocale" />
+		<property name="test.name.skip.portal.instance" value="CPWebcontent#AddStructureViaLocaleURL" />
 
 		<execute macro="Navigator#openSpecificURL">
 			<var name="url" value="http://localhost:8080/en/" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
@@ -230,7 +230,7 @@
 
 		<execute function="Pause" locator1="3000" />
 
-		<execute macro="Navigator#openLocaleURL">
+		<execute macro="Navigator#ensureLocaleURL">
 			<var name="localeURL" value="${portalURL}/en" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/cpwebcontent/CPWebcontent.testcase
@@ -207,6 +207,70 @@
 		</for>
 	</command>
 
+	<command name="AddStructureViaLocaleURL" priority="4">
+		<description message="This is a use case for LPS-77387." />
+
+		<property name="test.name.skip.portal.instance" value="CPWebcontent#AddStructureInEnLocale" />
+
+		<execute macro="Navigator#openSpecificURL">
+			<var name="url" value="http://localhost:8080/en/" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
+			<var name="portlet" value="Web Content" />
+		</execute>
+
+		<execute macro="WebContentNavigator#gotoManageStructures" />
+
+		<execute macro="LexiconEntry#gotoAdd" />
+
+		<execute function="Pause" locator1="3000" />
+
+		<execute macro="Navigator#openLocaleURL">
+			<var name="localeURL" value="http://localhost:8080/en" />
+		</execute>
+
+		<execute macro="WebContentStructures#addName">
+			<var name="structureName" value="WC Structure Name" />
+		</execute>
+
+		<execute macro="Panel#expandPanel">
+			<var name="panelHeading" value="Details" />
+		</execute>
+
+		<execute macro="PortletEntry#inputDescriptionTextInput">
+			<var name="description" value="WC Structure Description" />
+		</execute>
+
+		<execute function="SelectFrame" value1="relative=top" />
+
+		<execute macro="DynamicDataMapping#addField">
+			<var name="field" value="Text" />
+			<var name="fieldFieldLabel" value="Text" />
+			<var name="fieldName" value="Text" />
+		</execute>
+
+		<execute macro="WebContentStructures#saveCP">
+			<var name="structureName" value="WC Structure Name" />
+		</execute>
+
+		<execute macro="Navigator#openURL" />
+
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
+			<var name="portlet" value="Web Content" />
+		</execute>
+
+		<execute macro="WebContentNavigator#gotoManageStructures" />
+
+		<execute function="AssertElementNotPresent" locator1="DDMSelectStructure#DDM_STRUCTURE_TABLE_NAME_2">
+			<var name="key_ddlDataDefinitionName" value="WC Structure Name" />
+		</execute>
+	</command>
+
 	<command name="AddStructureWithSeparatorField" priority="4">
 		<description message="This is a use case for LPS-52248." />
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-37894
https://issues.liferay.com/browse/LRQA-38418

@anthony-chu some more forward-ports.

Something to note, the behavior on the test for 37894 is a little tricky because the /en/ locale needs to be in the URL upon creating the structure.  So that's why there's all the StringUtil to reconstruct the link for that purpose.  If you can think of a simpler regex or other way to do that, feel free to implement.

Thanks!