### PR TITLE
LRQA-33598, LRQA-38034, LRQA-38417 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
@@ -1345,11 +1345,9 @@
 	</command>
 
 	<command name="viewSelectedPG">
-		<var name="key_selectedAsset" value="${selectedAsset}" />
-
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
+		<execute function="Click#clickNoWaitForVisible" locator1="Portlet#ICON_PLUS_SIGN">
+			<var name="key_portletName" value="Asset Publisher" />
+		</execute>
 
 		<execute function="AssertTextEquals" locator1="MenuItem#ANY_MENU_ITEM" value1="${selectedAsset}">
 			<var name="key_menuItem" value="${selectedAsset}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
@@ -607,12 +607,9 @@
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
 
-		<var name="key_rowEntry" value="${configurationName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${configurationName}" />
 		</execute>
 
 		<execute function="Confirm#waitForConfirmation" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -702,12 +699,9 @@
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
 
-		<var name="key_rowEntry" value="${configurationName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Apply">
-			<var name="key_menuItem" value="Apply" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Apply" />
+			<var name="rowEntry" value="${configurationName}" />
 		</execute>
 
 		<execute macro="Alert#viewSuccessMessage" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -195,16 +195,8 @@
 	</command>
 
 	<command name="addViaAP">
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="AssertVisible" locator1="MenuItem#ANY_MENU_ITEM">
-			<var name="key_menuItem" value="Blogs Entry" />
-		</execute>
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Blogs Entry">
-			<var name="key_menuItem" value="Blogs Entry" />
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Blogs Entry" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
@@ -227,6 +219,10 @@
 	</command>
 
 	<command name="addViaAPSelectScope">
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Blogs Entry" />
+		</execute>
+
 		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
 
 		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
@@ -377,15 +373,9 @@
 	</command>
 
 	<command name="addWithWorkflowViaAP">
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Blogs Entry">
-			<var name="key_menuItem" value="Blogs Entry" />
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Blogs Entry" />
 		</execute>
-
-		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
 
 		<execute macro="AlloyEditor#addTitleAndContent">
 			<var name="content" value="${entryContent}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -198,15 +198,9 @@
 	</command>
 
 	<command name="addWithWorkflowPGViaAP">
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Blogs Entry">
-			<var name="key_menuItem" value="Blogs Entry" />
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Blogs Entry" />
 		</execute>
-
-		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
 
 		<execute macro="PortletEntry#inputTitle">
 			<var name="title" value="${entryTitle}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsNavigator.macro
@@ -32,12 +32,9 @@
 	</command>
 
 	<command name="gotoBlogsEntryPermissionsCP">
-		<var name="key_rowEntry" value="${entryTitle}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-			<var name="key_menuItem" value="Permissions" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Permissions" />
+			<var name="rowEntry" value="${entryTitle}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Bookmark.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Bookmark.macro
@@ -267,13 +267,13 @@
 
 	<command name="deletePG">
 		<var name="key_assetName" value="${bookmarkName}" />
-		<var name="key_rowEntry" value="${bookmarkName}" />
 
 		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${bookmarkName}" />
 
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${bookmarkName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 
@@ -291,12 +291,10 @@
 	<command name="editCP">
 		<var name="bookmarkName" value="${bookmarkName}" />
 		<var name="bookmarkURL" value="${bookmarkURL}" />
-		<var name="key_rowEntry" value="${bookmarkName}" />
 
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${bookmarkName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">
@@ -326,12 +324,10 @@
 	<command name="editPG">
 		<var name="bookmarkName" value="${bookmarkName}" />
 		<var name="bookmarkURL" value="${bookmarkURL}" />
-		<var name="key_rowEntry" value="${bookmarkName}" />
 
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${bookmarkName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">
@@ -365,12 +361,9 @@
 			</then>
 		</if>
 
-		<var name="key_rowEntry" value="${bookmarkName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Move">
-			<var name="key_menuItem" value="Move" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move" />
+			<var name="rowEntry" value="${bookmarkName}" />
 		</execute>
 
 		<execute function="AssertClick" locator1="Button#SELECT" value1="Select" />
@@ -404,12 +397,9 @@
 			</then>
 		</if>
 
-		<var name="key_rowEntry" value="${bookmarkName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Move">
-			<var name="key_menuItem" value="Move" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move" />
+			<var name="rowEntry" value="${bookmarkName}" />
 		</execute>
 
 		<execute function="AssertTextEquals" locator1="Portlet#HEADER" value1="Move Entries" />
@@ -455,22 +445,20 @@
 
 		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${bookmarkName}" />
 
-		<var name="key_rowEntry" value="${bookmarkName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${bookmarkName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 		<execute function="AssertTextNotPresent" locator1="Bookmarks#BOOKMARKS_TABLE_URL" value1="${bookmarkURL}" />
 	</command>
 
 	<command name="moveToRecycleBinPG">
-		<var name="key_rowEntry" value="${bookmarkName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${bookmarkName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BookmarksFolder.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BookmarksFolder.macro
@@ -143,14 +143,14 @@
 	</command>
 
 	<command name="deletePG">
-		<var name="key_assetName" value="${folderName}" />
-		<var name="key_rowEntry" value="${folderName}" />
+		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${folderName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 
@@ -166,12 +166,9 @@
 	</command>
 
 	<command name="editCP">
-		<var name="key_rowEntry" value="${folderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${folderName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">
@@ -191,12 +188,9 @@
 	</command>
 
 	<command name="editPG">
-		<var name="key_rowEntry" value="${folderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${folderName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">
@@ -216,22 +210,16 @@
 	</command>
 
 	<command name="editSubfolderCP">
-		<var name="key_assetName" value="${folderName}" />
-		<var name="key_rowEntry" value="${folderName}" />
-
-		<execute function="AssertClick" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
+		<execute function="AssertClick" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
 		<execute function="AssertTextEquals" locator1="Portlet#HEADER" value1="${folderName}" />
 
-		<var name="key_rowEntry" value="${subfolderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${folderName}" />
 		</execute>
-
-		<var name="key_folderName" value="${editSubfolderName}" />
 
 		<execute macro="PortletEntry#inputName">
 			<var name="name" value="${editSubfolderName}" />
@@ -250,9 +238,9 @@
 	</command>
 
 	<command name="gotoPG">
-		<var name="key_assetName" value="${folderName}" />
-
-		<execute function="AssertClick#assertPartialTextClickAt" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
+		<execute function="AssertClick#assertPartialTextClickAt" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
 		<execute macro="Breadcrumb#viewActiveEntry">
 			<var name="breadcrumbName" value="${folderName}" />
@@ -286,21 +274,16 @@
 	</command>
 
 	<command name="mergeSubfolderToFolderCP">
-		<var name="key_assetName" value="${folderName}" />
-
-		<execute function="AssertClick" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
+		<execute function="AssertClick" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
 		<execute function="AssertTextEquals" locator1="Portlet#HEADER" value1="${folderName}" />
 
-		<var name="key_rowEntry" value="${subfolderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${subfolderName}" />
 		</execute>
-
-		<var name="key_folderName" value="${editSubfolderName}" />
 
 		<execute function="Click" locator1="Bookmarks#PARENT_FOLDER_PANEL" />
 
@@ -308,25 +291,20 @@
 
 		<execute macro="Button#clickSave" />
 
-		<var name="key_bookmarkName" value="${bookmarkName}" />
-
 		<execute macro="Alert#viewSuccessMessage" />
 
 		<execute macro="Bookmark#viewBookmark">
 			<var name="bookmarkName" value="${bookmarkName}" />
 			<var name="bookmarkURL" value="${bookmarkURL}" />
-			<var name="key_assetName" value="${bookmarkName}" />
+			<var name="folderName" value="${bookmarkName}" />
 		</execute>
 	</command>
 
 	<command name="moveSubfolderToRecycleBinPG">
-		<var name="key_rowEntry" value="${subfolderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
-
-		<var name="key_assetType" value="Bookmarks Folder" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${subfolderName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 	</command>
@@ -340,23 +318,22 @@
 			<var name="portlet" value="Bookmarks" />
 		</execute>
 
-		<var name="key_assetName" value="${folderName}" />
+		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
-
-		<var name="key_rowEntry" value="${folderName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute macro="PortletEntry#clickMoveToRecycleBin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${folderName}" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 	</command>
 
 	<command name="subscribePG">
-		<var name="key_assetDescription" value="${folderDescription}" />
-
-		<execute function="AssertTextEquals#assertPartialText" locator1="Bookmarks#DESCRIPTIVE_ENTRY_DESCRIPTION" value1="${folderDescription}" />
+		<execute function="AssertTextEquals#assertPartialText" locator1="Bookmarks#DESCRIPTIVE_ENTRY_DESCRIPTION" value1="${folderDescription}">
+			<var name="key_assetDescription" value="${folderDescription}" />
+		</execute>
 
 		<execute function="Click#clickAt" locator1="Icon#INFO" />
 
@@ -400,12 +377,12 @@
 	</command>
 
 	<command name="viewFolder">
-		<var name="key_assetName" value="${folderName}" />
+		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}">
+			<var name="key_assetName" value="${folderName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_TITLE" value1="${folderName}" />
-
-		<var name="key_assetDescription" value="${folderDescription}" />
-
-		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_DESCRIPTION" value1="${folderDescription}" />
+		<execute function="AssertTextEquals" locator1="Bookmarks#DESCRIPTIVE_ENTRY_DESCRIPTION" value1="${folderDescription}">
+			<var name="key_assetDescription" value="${folderDescription}" />
+		</execute>
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Category.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Category.macro
@@ -1,14 +1,8 @@
 <definition>
 	<command name="addCategoryLocalizationCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Add Category">
-			<var name="key_menuItem" value="Add Category" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Add Category" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -42,15 +36,9 @@
 	</command>
 
 	<command name="addCategoryViewableByCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Add Category">
-			<var name="key_menuItem" value="Add Category" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Add Category" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -76,12 +64,9 @@
 				<execute function="AssertClick" locator1="Categories#ADD_CATEGORY_BUTTON" value1="Add Category" />
 			</then>
 			<else>
-				<var name="key_rowEntry" value="${vocabularyName}" />
-
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-				<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Add Category">
-					<var name="key_menuItem" value="Add Category" />
+				<execute macro="LexiconEntry#gotoEntryMenuItem">
+					<var name="menuItem" value="Add Category" />
+					<var name="rowEntry" value="${vocabularyName}" />
 				</execute>
 			</else>
 		</if>
@@ -148,14 +133,9 @@
 	</command>
 
 	<command name="addWithNullTitleCP">
-		<var name="key_vocabularyName" value="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Add Category">
-			<var name="key_menuItem" value="Add Category" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Add Category" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -203,17 +183,13 @@
 	</command>
 
 	<command name="deleteCategoryByMenuCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -224,26 +200,22 @@
 	</command>
 
 	<command name="deleteCategoryProperty2CP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute macro="Navigator#gotoNavUnderline">
 			<var name="navUnderline" value="Properties" />
 		</execute>
 
-		<var name="key_rowIndexNumber" value="2" />
-
-		<execute function="Click" locator1="Button#DELETE_ROW_N" />
+		<execute function="Click" locator1="Button#DELETE_ROW_N">
+			<var name="key_rowIndexNumber" value="2" />
+		</execute>
 
 		<execute function="AssertElementPresent" locator1="CategoriesEditCategory#PROPERTIES_UNDO_MESSAGE" />
 
@@ -251,9 +223,9 @@
 	</command>
 
 	<command name="deletePartialCategoryCP">
-		<var name="key_vocabularyName" value="${vocabularyName}" />
-
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
 		<execute function="Check#checkAll" locator1="Checkbox#SELECT_ALL" />
 
@@ -267,17 +239,13 @@
 	</command>
 
 	<command name="editCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -288,17 +256,13 @@
 	</command>
 
 	<command name="editPropertyCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute macro="Navigator#gotoNavUnderline">
@@ -337,25 +301,21 @@
 	</command>
 
 	<command name="viewCategoryPropertyCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<var name="i" value="0" />
-		<var name="pathNumber" value="0" />
-
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute macro="Navigator#gotoNavUnderline">
 			<var name="navUnderline" value="Properties" />
 		</execute>
+
+		<var name="i" value="0" />
+		<var name="pathNumber" value="0" />
 
 		<if>
 			<equals arg1="${propertyNumber}" arg2="0" />
@@ -393,17 +353,13 @@
 	</command>
 
 	<command name="viewCategoryViewableByCP">
-		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-			<var name="key_menuItem" value="Permissions" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Permissions" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ContentTargetingUserSegment.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ContentTargetingUserSegment.macro
@@ -318,13 +318,9 @@
 	</command>
 
 	<command name="deleteUserSegmentCP">
-		<var name="key_rowEntry" value="${userSegmentName}" />
-		<var name="key_userSegment" value="${userSegmentName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="ClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${userSegmentName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ContentTargetingUserSegment.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ContentTargetingUserSegment.macro
@@ -330,12 +330,9 @@
 	</command>
 
 	<command name="editGenderRule">
-		<var name="key_rowEntry" value="${userSegmentName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${userSegmentName}" />
 		</execute>
 
 		<execute macro="ContentTargetingUserSegment#openFormField">
@@ -346,13 +343,9 @@
 	</command>
 
 	<command name="editUserSegmentCP">
-		<var name="key_rowEntry" value="${userSegmentName}" />
-		<var name="key_userSegment" value="${userSegmentName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${userSegmentName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLNavigator.macro
@@ -96,16 +96,13 @@
 	</command>
 
 	<command name="gotoSpreadsheetView">
-		<var name="key_ddlListName" value="${ddlListName}" />
+		<execute function="AssertTextEquals" locator1="DDL#LIST_TABLE_NAME" value1="${ddlListName}">
+			<var name="key_ddlListName" value="${ddlListName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="DDL#LIST_TABLE_NAME" value1="${ddlListName}" />
-
-		<var name="key_rowEntry" value="${ddlListName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Spreadsheet View">
-			<var name="key_menuItem" value="Spreadsheet View" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Spreadsheet View" />
+			<var name="rowEntry" value="${ddlListName}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DDLRecord.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DDLRecord.macro
@@ -537,15 +537,13 @@
 			</then>
 		</if>
 
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View" />
+			<var name="rowEntry" value="${ddlRecordFieldData}" />
+		</execute>
+
 		<var name="key_ddlRecordFieldData" value="${ddlRecordFieldData}" />
 		<var name="key_fieldFieldLabel" value="${fieldFieldLabel}" />
-		<var name="key_rowEntry" value="${ddlRecordFieldData}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View">
-			<var name="key_menuItem" value="View" />
-		</execute>
 
 		<if>
 			<equals arg1="${ddlRecordFieldData}" arg2="" />
@@ -882,12 +880,9 @@
 
 		<execute function="AssertTextEquals" locator1="DDL#RECORD_TABLE_ENTRY_2" value1="${ddlRecordFieldData}" />
 
-		<var name="key_rowEntry" value="${ddlRecordFieldData}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View">
-			<var name="key_menuItem" value="View" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View" />
+			<var name="rowEntry" value="${ddlRecordFieldData}" />
 		</execute>
 
 		<if>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -546,15 +546,9 @@
 	</command>
 
 	<command name="addPGViaAPWithValidationPosition">
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Basic Document">
-			<var name="key_menuItem" value="Basic Document" />
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Basic Document" />
 		</execute>
-
-		<execute macro="IFrame#selectEditAssetFrame" />
 
 		<execute macro="DMDocument#editDocument">
 			<var name="dmDocumentDescription" value="${dmDocumentDescription}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -545,6 +545,29 @@
 		<execute function="SelectFrame" locator1="relative=top" />
 	</command>
 
+	<command name="addPGViaAPWithValidationPosition">
+		<execute function="Click#makeVisibleClickAt" locator1="AP#ADD_ASSET_PLUS_ICON" />
+
+		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Basic Document">
+			<var name="key_menuItem" value="Basic Document" />
+		</execute>
+
+		<execute macro="IFrame#selectDialogFrame" />
+
+		<execute macro="DMDocument#editDocument">
+			<var name="dmDocumentDescription" value="${dmDocumentDescription}" />
+			<var name="dmDocumentFile" value="${dmDocumentFile}" />
+			<var name="dmDocumentTitle" value="${dmDocumentTitle}" />
+		</execute>
+
+		<execute function="AssertElementPresent" locator1="Button#CANCEL_GIVEN_POSITION" />
+		<execute function="AssertElementPresent" locator1="Button#PUBLISH_GIVEN_POSITION" />
+
+		<execute function="AssertClick" locator1="Button#PUBLISH" value1="Publish" />
+
+		<execute function="SelectFrame" locator1="relative=top" />
+	</command>
+
 	<command name="addPGViaFlashUploader">
 		<if>
 			<equals arg1="${stagingActivated}" arg2="true" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -546,13 +546,15 @@
 	</command>
 
 	<command name="addPGViaAPWithValidationPosition">
-		<execute function="Click#makeVisibleClickAt" locator1="AP#ADD_ASSET_PLUS_ICON" />
+		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
+
+		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
 
 		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Basic Document">
 			<var name="key_menuItem" value="Basic Document" />
 		</execute>
 
-		<execute macro="IFrame#selectDialogFrame" />
+		<execute macro="IFrame#selectEditAssetFrame" />
 
 		<execute macro="DMDocument#editDocument">
 			<var name="dmDocumentDescription" value="${dmDocumentDescription}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMNavigator.macro
@@ -50,12 +50,9 @@
 	</command>
 
 	<command name="gotoDocumentPermissionsCP">
-		<var name="key_rowEntry" value="${dmDocumentTitle}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-			<var name="key_menuItem" value="Permissions" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Permissions" />
+			<var name="rowEntry" value="${dmDocumentTitle}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdmin.macro
@@ -3,12 +3,9 @@
 	<var name="formName" value="Created Form Name" />
 
 	<command name="deleteForm">
-		<var name="key_rowEntry" value="${formName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${formName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormsAdminNavigator.macro
@@ -149,12 +149,9 @@
 	</command>
 
 	<command name="gotoViewEntriesViaIcon">
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS">
-			<var name="key_rowEntry" value="${formName}" />
-		</execute>
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View Entries">
-			<var name="key_menuItem" value="View Entries" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View Entries" />
+			<var name="rowEntry" value="${formName}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticleSuggestion.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticleSuggestion.macro
@@ -53,45 +53,27 @@
 	</command>
 
 	<command name="moveToInProgressStatus">
-		<var name="key_kbArticleTitle" value="${kbArticleTitle}" />
-		<var name="key_kbSuggestionBody" value="${kbSuggestionBody}" />
-
-		<var name="key_rowEntry" value="${kbSuggestionBody}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Move to In Progress">
-			<var name="key_menuItem" value="Move to In Progress" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to In Progress" />
+			<var name="rowEntry" value="${kbSuggestionBody}" />
 		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 	</command>
 
 	<command name="moveToNewStatus">
-		<var name="key_kbArticleTitle" value="${kbArticleTitle}" />
-		<var name="key_kbSuggestionBody" value="${kbSuggestionBody}" />
-
-		<var name="key_rowEntry" value="${kbSuggestionBody}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Move to New">
-			<var name="key_menuItem" value="Move to New" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to New" />
+			<var name="rowEntry" value="${kbSuggestionBody}" />
 		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />
 	</command>
 
 	<command name="moveToResolvedStatus">
-		<var name="key_kbArticleTitle" value="${kbArticleTitle}" />
-		<var name="key_kbSuggestionBody" value="${kbSuggestionBody}" />
-
-		<var name="key_rowEntry" value="${kbSuggestionBody}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Resolve">
-			<var name="key_menuItem" value="Resolve" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Resolve" />
+			<var name="rowEntry" value="${kbSuggestionBody}" />
 		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBFolder.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBFolder.macro
@@ -45,12 +45,9 @@
 	</command>
 
 	<command name="deleteCP">
-		<var name="key_rowEntry" value="${kbFolderName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${kbFolderName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -59,12 +56,9 @@
 	</command>
 
 	<command name="editCP">
-		<var name="key_rowEntry" value="${kbFolderName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${kbFolderName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputName">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBTemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBTemplate.macro
@@ -15,12 +15,9 @@
 	<command name="gotoCP">
 		<execute function="AssertClick" locator1="NavBar#TEMPLATES" value1="Templates" />
 
-		<var name="key_rowEntry" value="${kbTemplateTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View">
-			<var name="key_menuItem" value="View" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View" />
+			<var name="rowEntry" value="${kbTemplateTitle}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LAR.macro
@@ -667,11 +667,9 @@
 	</command>
 
 	<command name="relaunchExport">
-		<var name="key_rowEntry" value="${larFileName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM">
-			<var name="key_menuItem" value="Relaunch" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Relaunch" />
+			<var name="rowEntry" value="${larFileName}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/PortletEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PortletEntry.macro
@@ -24,12 +24,9 @@
 	</command>
 
 	<command name="deleteViaMenuItem">
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS">
-			<var name="key_rowEntry" value="${rowEntry}" />
-		</execute>
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${rowEntry}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/RecycleBin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/RecycleBin.macro
@@ -77,16 +77,13 @@
 
 		<execute function="AssertClick" locator1="RecycleBin#RECYCLE_BIN_TABLE_NAME" value1="${assetName}" />
 
-		<var name="key_assetName" value="${documentName}" />
+		<execute function="AssertTextEquals" locator1="RecycleBin#RECYCLE_BIN_FOLDER_DOCUMENT_NAME" value1="${documentName}">
+			<var name="key_assetName" value="${documentName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="RecycleBin#RECYCLE_BIN_FOLDER_DOCUMENT_NAME" value1="${documentName}" />
-
-		<var name="key_rowEntry" value="${documentName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Restore">
-			<var name="key_menuItem" value="Restore" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Restore" />
+			<var name="rowEntry" value="${documentName}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="RecycleBin#RECYCLE_BIN_FOLDER_WARNING_IFRAME" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
@@ -307,6 +307,7 @@
 			<var name="roleTitle" value="${roleTitle}" />
 			<var name="roleType" value="${roleType}" />
 			<var name="roleUser" value="${roleUser}" />
+			<var name="siteNameScope" value="${siteNameScope}" />
 		</execute>
 
 		<execute macro="Role#viewPermissionCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
@@ -663,12 +663,9 @@
 						<var name="key_itemName" value="${siteName}" />
 					</execute>
 
-					<var name="key_rowEntry" value="${siteName}" />
-
-					<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-					<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Request Membership">
-						<var name="key_menuItem" value="Request Membership" />
+					<execute macro="LexiconEntry#gotoEntryMenuItem">
+						<var name="menuItem" value="Request Membership" />
+						<var name="rowEntry" value="${siteName}" />
 					</execute>
 
 					<execute function="Type" locator1="TextArea#COMMENTS" value1="Please allow me to join the Restricted Site." />
@@ -693,12 +690,9 @@
 					<var name="key_itemName" value="${siteName}" />
 				</execute>
 
-				<var name="key_rowEntry" value="${siteName}" />
-
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-				<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Join">
-					<var name="key_menuItem" value="Join" />
+				<execute macro="LexiconEntry#gotoEntryMenuItem">
+					<var name="menuItem" value="Join" />
+					<var name="rowEntry" value="${siteName}" />
 				</execute>
 
 				<execute macro="Alert#viewSuccessMessage" />
@@ -741,12 +735,9 @@
 			<var name="key_itemName" value="${siteName}" />
 		</execute>
 
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS">
-			<var name="key_rowEntry" value="${siteName}" />
-		</execute>
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Leave">
-			<var name="key_menuItem" value="Leave" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Leave" />
+			<var name="rowEntry" value="${siteName}" />
 		</execute>
 
 		<execute macro="Alert#viewSuccessMessage" />
@@ -836,12 +827,9 @@
 
 		<execute function="AssertTextEquals" locator1="Card#SPECIFIC_TEXT" value1="${userScreenName}" />
 
-		<var name="key_rowEntry" value="${key_cardText}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Remove Membership">
-			<var name="key_menuItem" value="Remove Membership" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Remove Membership" />
+			<var name="rowEntry" value="${userScreenName}" />
 		</execute>
 
 		<execute function="Confirm#waitForConfirmation" value1="Are you sure you want to delete this? It will be deleted immediately." />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -450,10 +450,6 @@
 	</command>
 
 	<command name="deletePageVariationPG">
-		<var name="key_PagesVariationName" value="${pageVariationName}" />
-
-		<var name="key_rowEntry" value="${pageVariationName}" />
-
 		<execute function="Click" locator1="Icon#STAGING_BAR_VERTICAL_ELLIPSIS" />
 
 		<execute function="Click" locator1="Staging#STAGING_MENU_MANAGE_PAGE_VARIATION" />
@@ -481,12 +477,9 @@
 			<var name="key_menuItem" value="Publish Templates" />
 		</execute>
 
-		<var name="key_rowEntry" value="${publishTemplateName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${publishTemplateName}" />
 		</execute>
 	</command>
 
@@ -691,12 +684,9 @@
 			<var name="key_menuItem" value="Publish Templates" />
 		</execute>
 
-		<var name="key_rowEntry" value="${publishTemplateName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Move to the Recycle Bin">
-			<var name="key_menuItem" value="Move to the Recycle Bin" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Move to the Recycle Bin" />
+			<var name="rowEntry" value="${publishTemplateName}" />
 		</execute>
 
 		<execute function="AssertElementPresent" locator1="Message#SUCCESS" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -460,10 +460,9 @@
 
 		<execute function="SelectFrame" locator1="IFrame#PAGE_VARIATION_IFRAME" />
 
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="ClickNoError" locator1="MenuItem#ANY_MENU_ITEM">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${pageVariationName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -494,15 +493,10 @@
 	<command name="deleteSitePagesVariationPG">
 		<execute macro="Staging#navigateToSitePageVariation" />
 
-		<var name="key_rowEntry" value="${sitePagesVariationName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="ClickNoError" locator1="MenuItem#ANY_MENU_ITEM">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${sitePagesVariationName}" />
 		</execute>
-
-		<var name="key_sitePagesVariationName" value="${sitePagesVariationName}" />
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
 
@@ -644,12 +638,9 @@
 
 		<execute macro="Staging#navigateToSitePageVariation" />
 
-		<var name="key_rowEntry" value="${sitePagesVariationName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Merge">
-			<var name="key_menuItem" value="Merge" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Merge" />
+			<var name="rowEntry" value="${sitePagesVariationName}" />
 		</execute>
 
 		<var name="key_sitePagesVariationMergeName" value="${sitePagesVariationMergeName}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Subcategory.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Subcategory.macro
@@ -38,16 +38,14 @@
 
 	<command name="addDuplicateCP">
 		<var name="key_categoryName" value="${categoryName}" />
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		
+		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${categoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Add Subcategory">
-			<var name="key_menuItem" value="Add Subcategory" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Add Subcategory" />
+			<var name="rowEntry" value="${categoryName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -107,12 +105,9 @@
 
 		<execute function="AssertClick" locator1="Categories#CATEGORY_ENTRY_LINK" value1="${categoryName}" />
 
-		<var name="key_rowEntry" value="${subcategoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${subcategoryName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -130,12 +125,9 @@
 
 		<execute function="AssertClick" locator1="Categories#CATEGORY_ENTRY_LINK" value1="${categoryName}" />
 
-		<var name="key_rowEntry" value="${subcategoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${subcategoryName}" />
 		</execute>
 
 		<execute macro="PortletEntry#inputTitle">
@@ -188,12 +180,9 @@
 
 		<execute function="Click" locator1="Categories#CATEGORY_ENTRY_LINK" />
 
-		<var name="key_rowEntry" value="${subcategoryName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${subcategoryName}" />
 		</execute>
 
 		<execute macro="Navigator#gotoNavUnderline">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Subcategory.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Subcategory.macro
@@ -38,7 +38,7 @@
 
 	<command name="addDuplicateCP">
 		<var name="key_categoryName" value="${categoryName}" />
-		
+
 		<execute function="AssertClick" locator1="Categories#VOCABULARY_ENTRY_LINK" value1="${vocabularyName}">
 			<var name="key_vocabularyName" value="${vocabularyName}" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/UserGroup.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/UserGroup.macro
@@ -122,10 +122,9 @@
 
 		<execute function="AssertElementPresent" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
 
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Assign Members">
-			<var name="key_menuItem" value="Assign Members" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Assign Members" />
+			<var name="rowEntry" value="${userGroupName}" />
 		</execute>
 
 		<execute function="AssertVisible" locator1="NavBar#USERS" />
@@ -166,12 +165,9 @@
 
 		<execute function="AssertTextEquals" locator1="UserGroups#USER_GROUP_TABLE_NAME" value1="${userGroupName}" />
 
-		<var name="key_rowEntry" value="${userGroupName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${userGroupName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -192,12 +188,9 @@
 
 		<execute function="AssertTextEquals" locator1="UserGroups#USER_GROUP_TABLE_NAME" value1="${userGroupName}" />
 
-		<var name="key_rowEntry" value="${userGroupName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${userGroupName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -332,17 +325,14 @@
 
 		<execute function="AssertTextEquals" locator1="UserGroups#USER_GROUP_TABLE_NAME" value1="${userGroupName}" />
 
-		<var name="key_rowEntry" value="${userGroupName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Assign Members">
-			<var name="key_menuItem" value="Assign Members" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Assign Members" />
+			<var name="rowEntry" value="${userGroupName}" />
 		</execute>
 
-		<var name="key_userScreenName" value="${userScreenName}" />
-
-		<execute function="AssertTextEquals" locator1="UserGroupsAssignUsers#USER_TABLE_SCREEN_NAME" value1="${userScreenName}" />
+		<execute function="AssertTextEquals" locator1="UserGroupsAssignUsers#USER_TABLE_SCREEN_NAME" value1="${userScreenName}">
+			<var name="key_userScreenName" value="${userScreenName}" />
+		</execute>
 	</command>
 
 	<command name="viewCP">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Vocabulary.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Vocabulary.macro
@@ -143,12 +143,9 @@
 
 		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}" />
 
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute macro="Panel#expandPanel">
@@ -177,16 +174,13 @@
 	</command>
 
 	<command name="deleteByMenuCP">
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -197,16 +191,13 @@
 	</command>
 
 	<command name="editCP">
-		<var name="key_vocabularyName" value="${vocabularyName}" />
+		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}">
+			<var name="key_vocabularyName" value="${vocabularyName}" />
+		</execute>
 
-		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}" />
-
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<if>
@@ -272,14 +263,11 @@
 		<if>
 			<equals arg1="${allowMultipleCategories}" arg2="false" />
 			<then>
-				<var name="key_rowEntry" value="${vocabularyName}" />
-
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-				<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-					<var name="key_menuItem" value="Edit" />
+				<execute macro="LexiconEntry#gotoEntryMenuItem">
+					<var name="menuItem" value="Edit" />
+					<var name="rowEntry" value="${vocabularyName}" />
 				</execute>
-
+				
 				<execute function="AssertNotChecked#assertNotCheckedNotVisible" locator1="CategoriesEditVocabulary#ALLOW_MULTIPLE_CATEGORIES_TOGGLE_SWITCH" />
 			</then>
 		</if>
@@ -321,12 +309,9 @@
 
 		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}" />
 
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-			<var name="key_menuItem" value="Permissions" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Permissions" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
@@ -358,12 +343,9 @@
 
 		<execute function="AssertTextEquals" locator1="Categories#VOCABULARY_ENTRY" value1="${vocabularyName}" />
 
-		<var name="key_rowEntry" value="${vocabularyName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${vocabularyName}" />
 		</execute>
 
 		<execute macro="Panel#expandPanel">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Vocabulary.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Vocabulary.macro
@@ -267,7 +267,7 @@
 					<var name="menuItem" value="Edit" />
 					<var name="rowEntry" value="${vocabularyName}" />
 				</execute>
-				
+
 				<execute function="AssertNotChecked#assertNotCheckedNotVisible" locator1="CategoriesEditVocabulary#ALLOW_MULTIPLE_CATEGORIES_TOGGLE_SWITCH" />
 			</then>
 		</if>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -461,6 +461,23 @@
 		<execute macro="PortletEntry#publish" />
 	</command>
 
+	<command name="addWithPermissionsCP">
+		<execute macro="WebContentNavigator#gotoAddCP" />
+
+		<execute macro="WebContent#addCP">
+			<var name="webContentContent" value="${webContentContent}" />
+			<var name="webContentTitle" value="${webContentTitle}" />
+		</execute>
+
+		<execute macro="Panel#expandPanel">
+			<var name="panelHeading" value="Permissions" />
+		</execute>
+
+		<execute function="Select" locator1="WCEditWebContent#PERMISSIONS_VIEWABLE_BY_SELECT" value1="${viewableBy}" />
+
+		<execute macro="PortletEntry#publish" />
+	</command>
+
 	<command name="addWithStructureAndWorkflowCP">
 		<execute macro="WebContent#addCP">
 			<var name="webContentTitle" value="${webContentTitle}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -42,6 +42,17 @@
 				</execute>
 			</then>
 		</if>
+
+		<if>
+			<isset var="viewableBy" />
+			<then>
+				<execute macro="Panel#expandPanel">
+					<var name="panelHeading" value="Permissions" />
+				</execute>
+
+				<execute function="Select" locator1="WCEditWebContent#PERMISSIONS_VIEWABLE_BY_SELECT" value1="${viewableBy}" />
+			</then>
+		</if>
 	</command>
 
 	<command name="addDraft">
@@ -457,23 +468,6 @@
 			<var name="categoryNameList" value="${categoryNameList}" />
 			<var name="vocabularyName" value="${vocabularyName}" />
 		</execute>
-
-		<execute macro="PortletEntry#publish" />
-	</command>
-
-	<command name="addWithPermissionsCP">
-		<execute macro="WebContentNavigator#gotoAddCP" />
-
-		<execute macro="WebContent#addCP">
-			<var name="webContentContent" value="${webContentContent}" />
-			<var name="webContentTitle" value="${webContentTitle}" />
-		</execute>
-
-		<execute macro="Panel#expandPanel">
-			<var name="panelHeading" value="Permissions" />
-		</execute>
-
-		<execute function="Select" locator1="WCEditWebContent#PERMISSIONS_VIEWABLE_BY_SELECT" value1="${viewableBy}" />
 
 		<execute macro="PortletEntry#publish" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -875,12 +875,9 @@
 	</command>
 
 	<command name="deleteWithDisabledRB">
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS">
-			<var name="key_rowEntry" value="${entryTitle}" />
-		</execute>
-
-		<execute function="ClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${entryTitle}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -1063,12 +1060,9 @@
 	</command>
 
 	<command name="expireSpecificVersionCP">
-		<var name="key_rowEntry" value="${webContentTitle}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View History">
-			<var name="key_menuItem" value="View History" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View History" />
+			<var name="rowEntry" value="${webContentTitle}" />
 		</execute>
 
 		<if>
@@ -1105,12 +1099,9 @@
 	</command>
 
 	<command name="gotoViewSpecificVersionHistoryCP">
-		<var name="key_rowEntry" value="${webContentTitle}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View History">
-			<var name="key_menuItem" value="View History" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View History" />
+			<var name="rowEntry" value="${webContentTitle}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContent.macro
@@ -762,12 +762,8 @@
 	</command>
 
 	<command name="addWithWorkflowPGViaAP">
-		<execute function="MouseOver#mouseOverNotVisible" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="Click" locator1="AP#ADD_ASSET_PLUS_ICON" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Basic Web Content">
-			<var name="key_menuItem" value="Basic Web Content" />
+		<execute macro="AssetPublisherPortlet#addAsset">
+			<var name="assetType" value="Basic Web Content" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentStructures.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentStructures.macro
@@ -153,12 +153,9 @@
 			<var name="searchTerm" value="${substructureName}" />
 		</execute>
 
-		<var name="key_rowEntry" value="${substructureName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit Default Values">
-			<var name="key_menuItem" value="Edit Default Values" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit Default Values" />
+			<var name="rowEntry" value="${substructureName}" />
 		</execute>
 
 		<for list="${editSubstructureFieldNames}" param="structureFieldName">
@@ -202,12 +199,9 @@
 		<if>
 			<isset var="addRoleViewPermissions" />
 			<then>
-				<var name="key_rowEntry" value="${structureName}" />
-
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-				<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-					<var name="key_menuItem" value="Permissions" />
+				<execute macro="LexiconEntry#gotoEntryMenuItem">
+					<var name="menuItem" value="Permissions" />
+					<var name="rowEntry" value="${structureName}" />
 				</execute>
 
 				<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WebContentTemplates.macro
@@ -91,12 +91,9 @@
 	</command>
 
 	<command name="addRoleViewPermissions">
-		<var name="key_rowEntry" value="${templateName}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Permissions">
-			<var name="key_menuItem" value="Permissions" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Permissions" />
+			<var name="rowEntry" value="${templateName}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Workflow.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Workflow.macro
@@ -391,12 +391,9 @@
 	</command>
 
 	<command name="gotoEditWorkflowDefinition">
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 	</command>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Workflow.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Workflow.macro
@@ -19,33 +19,28 @@
 	</command>
 
 	<command name="_tearDownWorkflow">
-		<var name="key_rowEntry" value="Knowledge Base Article" />
 		<var name="noWorkflow" value="No Workflow" />
 
 		<if>
 			<condition function="IsElementPresent" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
 			<then>
-				<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-				<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-					<var name="key_menuItem" value="Edit" />
+				<execute macro="LexiconEntry#gotoEntryMenuItem">
+					<var name="menuItem" value="Edit" />
+					<var name="rowEntry" value="Knowledge Base Article" />
 				</execute>
 
-				<var name="key_workflowResourceValue" value="Knowledge Base Article" />
-
-				<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="${noWorkflow}" />
+				<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="${noWorkflow}">
+					<var name="key_workflowResourceValue" value="Knowledge Base Article" />
+				</execute>
 
 				<execute macro="Button#clickSave" />
 			</then>
 		</if>
 
 		<for list="Blogs Entry,Calendar Event,Comment,Message Boards Message,Page Revision,Wiki Page" param="workflowResourceValue">
-			<var name="key_rowEntry" value="${workflowResourceValue}" />
-
-			<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-			<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-				<var name="key_menuItem" value="Edit" />
+			<execute macro="LexiconEntry#gotoEntryMenuItem">
+				<var name="menuItem" value="Edit" />
+				<var name="rowEntry" value="${workflowResourceValue}" />
 			</execute>
 
 			<var name="key_workflowResourceValue" value="${workflowResourceValue}" />
@@ -286,19 +281,16 @@
 	</command>
 
 	<command name="configureWorkflow">
-		<var name="key_rowEntry" value="${workflowResourceValue}" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${workflowResourceValue}" />
 		</execute>
 
 		<execute function="AssertTextEquals" locator1="Portlet#HEADER" value1="${workflowResourceValue}" />
 
-		<var name="key_workflowResourceValue" value="${workflowResourceValue}" />
-
-		<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="${workflowDefinition}" />
+		<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="${workflowDefinition}">
+			<var name="key_workflowResourceValue" value="${workflowResourceValue}" />
+		</execute>
 
 		<execute macro="PortletEntry#save" />
 
@@ -631,18 +623,14 @@
 
 		<execute macro="Workflow#_tearDownWorkflow" />
 
-		<var name="key_rowEntry" value="User" />
-		<var name="noWorkflow" value="No Workflow" />
-
-		<execute function="Click#waitForMenuToggleJSClick" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="Click" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="User" />
 		</execute>
 
-		<var name="key_workflowResourceValue" value="User" />
-
-		<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="${noWorkflow}" />
+		<execute function="Select" locator1="WorkflowConfiguration#RESOURCE_TABLE_SELECT" value1="No Workflow">
+			<var name="key_workflowResourceValue" value="User" />
+		</execute>
 
 		<execute macro="Button#clickSave" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ee/KaleoFormsAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ee/KaleoFormsAdmin.macro
@@ -102,14 +102,9 @@
 			</then>
 		</if>
 
-		<var name="key_rowEntry" value="${workflowTask}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<var name="key_workflowTask" value="${workflowTask}" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Assign Form">
-			<var name="key_menuItem" value="Assign Form" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Assign Form" />
+			<var name="rowEntry" value="${workflowTask}" />
 		</execute>
 	</command>
 
@@ -162,12 +157,9 @@
 			</then>
 		</if>
 
-		<var name="key_rowEntry" value="${kfFieldSetName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Choose">
-			<var name="key_menuItem" value="Choose" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Choose" />
+			<var name="rowEntry" value="${kfFieldSetName}" />
 		</execute>
 
 		<execute function="AssertTextEquals" locator1="KaleoFormsAdminEditProcess#SELECTED_FIELD_SET" value1="${kfFieldSetName}" />
@@ -210,12 +202,9 @@
 			</else>
 		</if>
 
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Choose">
-			<var name="key_menuItem" value="Choose" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Choose" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 
 		<execute macro="KaleoFormsAdmin#viewSelectedWorkflow">
@@ -225,11 +214,9 @@
 	</command>
 
 	<command name="deactivateWorkflow">
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Deactivate">
-			<var name="key_menuItem" value="Deactivate" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Deactivate" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to deactivate this?" />
@@ -270,12 +257,9 @@
 			<var name="searchTerm" value="${kfFormName}" />
 		</execute>
 
-		<var name="key_rowEntry" value="${kfFormName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${kfFormName}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -330,11 +314,9 @@
 	</command>
 
 	<command name="deleteWorkflowDraft">
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClickNoError" locator1="MenuItem#ANY_MENU_ITEM" value1="Delete">
-			<var name="key_menuItem" value="Delete" />
+		<execute macro="LexiconEntry#gotoEntryMenuItemNoError">
+			<var name="menuItem" value="Delete" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 
 		<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
@@ -348,11 +330,9 @@
 			<var name="kfProgressStep" value="2" />
 		</execute>
 
-		<var name="key_rowEntry" value="${kfFieldSetName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${kfFieldSetName}" />
 		</execute>
 
 		<var name="key_iframeTitle" value="Field Set" />
@@ -383,12 +363,9 @@
 
 		<execute function="AssertClick" locator1="KaleoFormsAdminEditProcessForm#FORM_TABLE_NAME" value1="${kfFormName}" />
 
-		<var name="key_rowEntry" value="${kfFormName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit Form">
-			<var name="key_menuItem" value="Edit Form" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit Form" />
+			<var name="rowEntry" value="${kfFormName}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
@@ -405,11 +382,9 @@
 	</command>
 
 	<command name="editProcess">
-		<var name="key_rowEntry" value="${kfProcessName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${kfProcessName}" />
 		</execute>
 	</command>
 
@@ -452,12 +427,9 @@
 			<var name="kfProgressStep" value="3" />
 		</execute>
 
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
@@ -472,22 +444,16 @@
 
 		<execute function="AssertTextEquals" locator1="KaleoFormsAdminEditProcess#WORKFLOW_TABLE_TITLE" value1="${workflowDefinitionTitle}" />
 
-		<var name="key_rowEntry" value="${workflowDefinitionTitle}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-			<var name="key_menuItem" value="Edit" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit" />
+			<var name="rowEntry" value="${workflowDefinitionTitle}" />
 		</execute>
 	</command>
 
 	<command name="exportRecords">
-		<var name="key_rowEntry" value="${kfProcessName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Export">
-			<var name="key_menuItem" value="Export" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Export" />
+			<var name="rowEntry" value="${kfProcessName}" />
 		</execute>
 
 		<execute function="Select" locator1="KaleoFormsAdminViewProcessRecords#EXPORT_DIALOG_BOX_FILE_EXTENSION_SELECT" value1="${fileExtension}" />
@@ -711,14 +677,9 @@
 			<var name="kfProgressName" value="Forms" />
 		</execute>
 
-		<var name="key_rowEntry" value="${workflowTask}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<var name="key_workflowTask" value="${workflowTask}" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Unassign Form">
-			<var name="key_menuItem" value="Unassign Form" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Unassign Form" />
+			<var name="rowEntry" value="${workflowTask}" />
 		</execute>
 	</command>
 
@@ -737,12 +698,9 @@
 	</command>
 
 	<command name="viewFormEdit">
-		<var name="key_rowEntry" value="${kfFormNameEdit}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit Form">
-			<var name="key_menuItem" value="Edit Form" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Edit Form" />
+			<var name="rowEntry" value="${kfFormNameEdit}" />
 		</execute>
 
 		<execute function="SelectFrame" locator1="IFrame#DIALOG" />
@@ -894,20 +852,16 @@
 	</command>
 
 	<command name="viewProcessRecord">
-		<var name="key_rowEntry" value="${kfProcessName}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View">
-			<var name="key_menuItem" value="View" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View" />
+			<var name="rowEntry" value="${kfProcessName}" />
 		</execute>
 	</command>
 
 	<command name="viewProcessRecordDetails">
-		<var name="key_rowEntry" value="${kfProcessFieldData}" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="View">
-			<var name="key_menuItem" value="View" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="View" />
+			<var name="rowEntry" value="${kfProcessFieldData}" />
 		</execute>
 
 		<execute function="AssertTextEquals" locator1="KaleoFormsAdminViewProcessRecordsDetails#CURRENT_RECORD_STATUS" value1="${kfStatus}" />

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Button.path
@@ -194,6 +194,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>CANCEL_GIVEN_POSITION</td>
+	<td>//div[contains(@class,'lfr-form-content')]/../div/a[contains(@class,'cancel') and contains(@class,'btn')] | //button[contains(.,'Cancel')] | //a[contains(@class,'btn') and contains(.,'Cancel')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>CHANGE</td>
 	<td>//button[contains(.,'Change')]</td>
 	<td></td>
@@ -546,6 +551,11 @@
 <tr>
 	<td>PUBLISH</td>
 	<td>//button[span[contains(.,'Publish')]]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>PUBLISH_GIVEN_POSITION</td>
+	<td>//div[contains(@class,'lfr-form-content')]/../div/button[span[contains(.,'Publish')]]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissions.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissions.path
@@ -330,6 +330,16 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_GENERAL_PERMISSIONS_VIEW_CHANGE_LINK</td>
+	<td>//a[contains(@id,'PortletVIEW')]/span[contains(.,'Change')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_GENERAL_PERMISSIONS_VIEW_SITE_SCOPE</td>
+	<td>//span[contains(@id,'groupHTMLcom_liferay_journal_web_portlet_JournalPortletVIEW')]/span[contains(.,'${key_siteNameScope}')]/span</td>
+	<td></td>
+</tr>
+<tr>
 	<td></td>
 	<td></td>
 	<td></td>
@@ -405,6 +415,21 @@
 <tr>
 	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_RESOURCE_PERMISSIONS_WEB_CONTENT_ARTICLE_UPDATE_CHECKBOX</td>
 	<td>//tbody//input[contains(@value,'JournalArticleUPDATE')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_RESOURCE_PERMISSIONS_WEB_CONTENT_ARTICLE_VIEW_CHECKBOX</td>
+	<td>//tbody//input[contains(@value,'JournalArticleVIEW')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_RESOURCE_PERMISSIONS_WEB_CONTENT_ARTICLE_VIEW_CHANGE_LINK</td>
+	<td>//tbody//a[contains(@id,'JournalArticleVIEW')]/span[contains(.,'Change')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>SITE_ADMIN_CONTENT_WEB_CONTENT_RESOURCE_PERMISSIONS_WEB_CONTENT_ARTICLE_VIEW_SITE_SCOPE</td>
+	<td>//span[contains(@id,'groupHTMLcom.liferay.journal.model.JournalArticleVIEW')]/span[contains(.,'${key_siteNameScope}')]/span</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSelectSite.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/roles/RolesPermissionsSelectSite.path
@@ -11,7 +11,7 @@
 <!--SELECT_SITE-->
 <tr>
 	<td>SELECT_SITE_IFRAME</td>
-	<td>//iframe[contains(@id,'selectGroupcomliferaybookmarksmodelBookmarksEntryVIEW_iframe_')]</td>
+	<td>//iframe[contains(@id,'selectGroup')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/usecase/SearchUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/usecase/SearchUsecase.testcase
@@ -1365,7 +1365,7 @@
 		</execute>
 
 		<execute macro="MessageboardsThread#addPG">
-			<var name="threadBody"><![CDATA[<script>alert("Liferay Alert")</script>]]></var>
+			<var name="threadBody"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="threadSubject" value="Thread Subject" />
 		</execute>
 
@@ -1376,8 +1376,14 @@
 		<execute macro="SearchPortlet#viewSearchResultPG">
 			<var name="searchAssetTitle" value="Thread Subject" />
 			<var name="searchAssetType" value="Message Boards Message" />
-			<var name="searchAssetSummary"><![CDATA[<script>alert("Liferay Alert")</script>]]></var>
+			<var name="searchAssetSummary"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewSearchResultForLongURL" priority="4">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/usecase/SolrSearchUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/usecase/SolrSearchUsecase.testcase
@@ -1335,7 +1335,7 @@
 		</execute>
 
 		<execute macro="MessageboardsThread#addPG">
-			<var name="threadBody"><![CDATA[<script>alert("Liferay Alert")</script>]]></var>
+			<var name="threadBody"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="threadSubject" value="Thread Subject" />
 		</execute>
 
@@ -1346,8 +1346,14 @@
 		<execute macro="SearchPortlet#viewSearchResultPG">
 			<var name="searchAssetTitle" value="Thread Subject" />
 			<var name="searchAssetType" value="Message Boards Message" />
-			<var name="searchAssetSummary"><![CDATA[<script>alert("Liferay Alert")</script>]]></var>
+			<var name="searchAssetSummary"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewSearchResultForLongURL" priority="4">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/usecase/XssUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/usecase/XssUsecase.testcase
@@ -95,7 +95,7 @@
 		</execute>
 
 		<execute macro="User#editDetailsViaMyAccount">
-			<var name="userLastNameEdit"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="userLastNameEdit"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Navigator#openURL" />
@@ -116,10 +116,16 @@
 		</execute>
 
 		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewControlPanelNoXSS" priority="5">
-		<var name="siteName"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+		<var name="siteName"><![CDATA[<script>alert(123);</script>]]></var>
 
 		<execute macro="ProductMenu#gotoPortlet">
 			<var name="category" value="Sites" />
@@ -146,6 +152,12 @@
 		<execute function="AssertClick" locator1="ContentRow#ENTRY_CONTENT_ENTRY_NAME_LINK" value1="${siteName}" />
 
 		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<execute function="AssertTextEquals" locator1="Portlet#HEADER" value1="Pages" />
 
@@ -225,11 +237,11 @@
 		</execute>
 
 		<execute macro="SitePages#addPublicPage">
-			<var name="pageName"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="pageName"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Navigator#gotoPage">
-			<var name="pageName"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="pageName"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Portlet#addPG">
@@ -241,7 +253,13 @@
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+		<execute function="AssertElementNotPresent" locator1="//body[.='123']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewMobileDeviceRulesNoXSS" priority="5">
@@ -285,10 +303,16 @@
 		</execute>
 
 		<execute function="AssertElementNotPresent" locator1="//body[.='123']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewRecycleBinNoXSS" priority="5">
-		<var name="entryTitle"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+		<var name="entryTitle"><![CDATA[<script>alert(123);</script>]]></var>
 
 		<execute macro="Navigator#openURL" />
 
@@ -342,7 +366,13 @@
 			<var name="assetType" value="Blogs Entry" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+		<execute function="AssertElementNotPresent" locator1="//body[.='123']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewRolesNoXSS" priority="4">
@@ -353,7 +383,7 @@
 		</execute>
 
 		<execute macro="Role#add">
-			<var name="roleTitle"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="roleTitle"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="ProductMenu#gotoPortlet">
@@ -363,7 +393,7 @@
 		</execute>
 
 		<execute macro="Role#viewCP">
-			<var name="roleTitle"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="roleTitle"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="roleType" value="Regular" />
 		</execute>
 
@@ -377,7 +407,13 @@
 			<var name="portletName" value="Sign In" />
 		</execute>
 
-		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+		<execute function="AssertElementNotPresent" locator1="//body[.='123']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewURLValidateNoXSS" priority="5">
@@ -462,9 +498,9 @@
 		</execute>
 
 		<execute macro="User#editDetailsViaMyAccount">
-			<var name="userFirstNameEdit"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
-			<var name="userLastNameEdit"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
-			<var name="userMiddleNameEdit"><![CDATA[<script>document.write("XSS"); window.stop();</script>]]></var>
+			<var name="userFirstNameEdit"><![CDATA[<script>alert(123);</script>]]></var>
+			<var name="userLastNameEdit"><![CDATA[<script>alert(123);</script>]]></var>
+			<var name="userMiddleNameEdit"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Navigator#openURL" />
@@ -489,5 +525,11 @@
 		</execute>
 
 		<execute function="AssertElementNotPresent" locator1="//body[.='XSS']" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/usecase/MessageboardsUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/messageboards/usecase/MessageboardsUsecase.testcase
@@ -506,8 +506,8 @@
 		</execute>
 
 		<execute macro="JSONMBMessage#addMessage">
-			<var name="threadBody"><![CDATA[<script>alert(2)</script>]]></var>
-			<var name="threadSubject"><![CDATA[<script>alert(1)</script>]]></var>
+			<var name="threadBody"><![CDATA[<script>alert(123);</script>]]></var>
+			<var name="threadSubject"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Navigator#gotoPage">
@@ -522,10 +522,16 @@
 		</execute>
 
 		<execute macro="MessageboardsThread#viewBBCodeNoXSS">
-			<var name="threadBody"><![CDATA[<script>alert(2)</script>]]></var>
-			<var name="threadSubject"><![CDATA[<script>alert(1)</script>]]></var>
+			<var name="threadBody"><![CDATA[<script>alert(123);</script>]]></var>
+			<var name="threadSubject"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="userName" value="Anonymous" />
 		</execute>
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewCategoriesAndThreadsOnTwoScopes" priority="3">
@@ -1880,13 +1886,19 @@
 
 		<execute macro="MessageboardsThread#addPG">
 			<var name="threadBody" value="" />
-			<var name="threadSubject"><![CDATA[<script>alert(1)</script>]]></var>
+			<var name="threadSubject"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="MessageboardsThread#viewNoXSSPG">
 			<var name="threadBody" value="" />
-			<var name="threadSubject"><![CDATA[<script>alert(1)</script>]]></var>
+			<var name="threadSubject"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewNoMBThreadXSS" priority="4">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/usecase/WikiUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/usecase/WikiUsecase.testcase
@@ -623,12 +623,18 @@
 		</execute>
 
 		<execute macro="WikiPage#editFrontPagePG">
-			<var name="wikiPageContentEdit"><![CDATA[<script>alert("xss")</script>]]></var>
+			<var name="wikiPageContentEdit"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute function="AssertClick" locator1="Link#EDIT" value1="Edit" />
 
 		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="ViewWikiDraftPagesViaBreadcrumb" priority="4">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/knowledgebase/usecase/KnowledgebaseUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/knowledgebase/usecase/KnowledgebaseUsecase.testcase
@@ -600,12 +600,9 @@
 				<var name="portlet" value="Knowledge Base" />
 			</execute>
 
-			<var name="key_rowEntry" value="${kbEntry}" />
-
-			<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-			<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Edit">
-				<var name="key_menuItem" value="Edit" />
+			<execute macro="LexiconEntry#gotoEntryMenuItem">
+				<var name="menuItem" value="Edit" />
+				<var name="rowEntry" value="${kbEntry}" />
 			</execute>
 
 			<execute function="AssertTextEquals" locator1="TextInput#CUSTOM_FIELD" value1="01/01/${kbEntry}" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitepagesadministration/usecase/SitepagesUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitepagesadministration/usecase/SitepagesUsecase.testcase
@@ -43,7 +43,7 @@
 	<command name="AddSitePageXSS" priority="3">
 		<property name="testray.component.names" value="Site Pages Administration,XSS" />
 
-		<var name="sitePage3Name"><![CDATA[<script>alert("Site Page 3")</script> />]]></var>
+		<var name="sitePage3Name"><![CDATA[<script>alert(123);</script>]]></var>
 
 		<execute macro="ProductMenu#gotoPortlet">
 			<var name="category" value="Navigation" />
@@ -87,6 +87,14 @@
 		<var name="key_pageName" value="${sitePage3Name}" />
 
 		<execute function="AssertTextEquals" locator1="Home#PAGE" value1="${sitePage3Name}" />
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 
 	<command name="CannotDeleteLastPublicPageOnLiferay" priority="3">

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/usecase/SitesadministrationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/usecase/SitesadministrationUsecase.testcase
@@ -1545,8 +1545,8 @@
 		</execute>
 
 		<execute macro="Team#addCP">
-			<var name="teamDescription"><![CDATA[<script>alert(123)</script>]]></var>
-			<var name="teamName"><![CDATA[<script>alert(123)</script>]]></var>
+			<var name="teamDescription"><![CDATA[<script>alert(123);</script>]]></var>
+			<var name="teamName"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="ProductMenu#gotoPortlet">
@@ -1556,7 +1556,15 @@
 		</execute>
 
 		<execute macro="Site#assignDefaultSiteTeam">
-			<var name="teamName"><![CDATA[<script>alert(123)</script>]]></var>
+			<var name="teamName"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitetemplates/cpsitetemplates/CPSitetemplates.testcase
@@ -671,5 +671,11 @@
 		</execute>
 
 		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
@@ -126,7 +126,8 @@
 	</command>
 
 	<command name="AddAssetTypesViaAPAndAddRespectivePortletsToSamePage" priority="5">
-		<description message="This is a use case for LPS-47619." />
+		<description message="This is a use case for LPS-47619 and LPS-67326." />
+
 		<property name="osgi.app.includes" value="knowledge-base" />
 		<property name="plugins.deployment.type" value="osgi" />
 
@@ -193,7 +194,7 @@
 			<var name="pageName" value="Asset Publisher Page" />
 		</execute>
 
-		<execute macro="DMDocument#addPGViaAP">
+		<execute macro="DMDocument#addPGViaAPWithValidationPosition">
 			<var name="dmDocumentDescription" value="DM Document Description" />
 			<var name="dmDocumentFile" value="Document_1.doc" />
 			<var name="dmDocumentTitle" value="DM Document Title" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
@@ -805,11 +805,15 @@
 			<var name="portlet" value="Web Content" />
 		</execute>
 
-		<execute macro="WebContent#addWithPermissionsCP">
+		<execute macro="WebContentNavigator#gotoAddCP" />
+
+		<execute macro="WebContent#addCP">
 			<var name="viewableBy" value="Site Members" />
 			<var name="webContentContent" value="WC WebContent Content" />
 			<var name="webContentTitle" value="WC WebContent Title" />
 		</execute>
+
+		<execute macro="PortletEntry#publish" />
 
 		<execute macro="Navigator#gotoPage">
 			<var name="pageName" value="Asset Publisher Page" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisherWebcontent.testcase
@@ -769,4 +769,75 @@
 			<var name="webContentTitle" value="WC Webcontent Title" />
 		</execute>
 	</command>
+
+	<command name="ViewWebContentViaAPAsGuestWithViewPermission" priority="5">
+		<description message="This is a use case for LPS-49853." />
+
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Users" />
+			<var name="panel" value="Control Panel" />
+			<var name="portlet" value="Roles" />
+		</execute>
+
+		<execute macro="Role#definePermissionCP">
+			<var name="permissionDefinitionKey" value="SITE_ADMIN_CONTENT_WEB_CONTENT_GENERAL_PERMISSIONS_VIEW_CHECKBOX" />
+			<var name="permissionDefinitionValue" value="View" />
+			<var name="roleName" value="Guest" />
+			<var name="siteNameScope" value="Liferay" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Users" />
+			<var name="panel" value="Control Panel" />
+			<var name="portlet" value="Roles" />
+		</execute>
+
+		<execute macro="Role#definePermissionCP">
+			<var name="permissionDefinitionKey" value="SITE_ADMIN_CONTENT_WEB_CONTENT_RESOURCE_PERMISSIONS_WEB_CONTENT_ARTICLE_VIEW_CHECKBOX" />
+			<var name="permissionDefinitionValue" value="View" />
+			<var name="roleName" value="Guest" />
+			<var name="siteNameScope" value="Liferay" />
+		</execute>
+
+		<execute macro="ProductMenu#gotoPortlet">
+			<var name="category" value="Content" />
+			<var name="panel" value="Site Administration" />
+			<var name="portlet" value="Web Content" />
+		</execute>
+
+		<execute macro="WebContent#addWithPermissionsCP">
+			<var name="viewableBy" value="Site Members" />
+			<var name="webContentContent" value="WC WebContent Content" />
+			<var name="webContentTitle" value="WC WebContent Title" />
+		</execute>
+
+		<execute macro="Navigator#gotoPage">
+			<var name="pageName" value="Asset Publisher Page" />
+		</execute>
+
+		<execute macro="AssetPublisherPortlet#configureAssetTypePG">
+			<var name="assetSubtype" value="Any" />
+			<var name="selectedAsset" value="Web Content Article" />
+		</execute>
+
+		<execute macro="Navigator#gotoPage">
+			<var name="pageName" value="Asset Publisher Page" />
+		</execute>
+
+		<execute macro="AssetPublisherPortlet#viewAssetPG">
+			<var name="assetContent" value="WC WebContent Content" />
+			<var name="assetTitle" value="WC WebContent Title" />
+		</execute>
+
+		<execute macro="User#logoutPG" />
+
+		<execute macro="Navigator#gotoPage">
+			<var name="pageName" value="Asset Publisher Page" />
+		</execute>
+
+		<execute macro="AssetPublisherPortlet#viewAssetPG">
+			<var name="assetContent" value="WC WebContent Content" />
+			<var name="assetTitle" value="WC WebContent Title" />
+		</execute>
+	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowUsecase.testcase
@@ -1681,16 +1681,24 @@
 		<execute macro="WebContentNavigator#gotoAddCP" />
 
 		<execute macro="WebContent#addWithWorkflowCP">
-			<var name="webContentContent"><![CDATA[&lt;script&gt;alert("web content article")&lt;/script&gt;]]></var>
+			<var name="webContentContent"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
 			<var name="webContentTitle" value="WC WebContent Title" />
 		</execute>
 
 		<execute macro="WebContent#viewWithWorkflowCP">
-			<var name="webContentContent"><![CDATA[<script>alert("web content article")</script>]]></var>
+			<var name="webContentContent"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="webContentTitle" value="WC WebContent Title" />
 			<var name="workflowStatus" value="Pending" />
 			<var name="workflowTask" value="Review" />
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -1704,8 +1712,16 @@
 			<var name="workflowAssetTitle" value="WC WebContent Title" />
 			<var name="workflowAssetType" value="Web Content Article" />
 			<var name="workflowTask" value="Review" />
-			<var name="workflowActivityComment"><![CDATA[<script>alert("web commenting on WC")</script>]]></var>
+			<var name="workflowActivityComment"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -1719,8 +1735,16 @@
 			<var name="workflowAssetTitle" value="WC WebContent Title" />
 			<var name="workflowAssetType" value="Web Content Article" />
 			<var name="workflowTask" value="Review" />
-			<var name="workflowActivityComment"><![CDATA[<script>alert("approve")</script>]]></var>
+			<var name="workflowActivityComment"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<execute macro="Navigator#openURL" />
 
@@ -1735,9 +1759,17 @@
 		</execute>
 
 		<execute macro="WebContent#viewCP">
-			<var name="webContentContent"><![CDATA[<script>alert("web content article")</script>]]></var>
+			<var name="webContentContent"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="webContentTitle" value="WC WebContent Title" />
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<execute macro="ProductMenu#gotoPortlet">
 			<var name="category" value="Sites" />
@@ -1769,8 +1801,16 @@
 		</execute>
 
 		<execute macro="WebContent#viewPGViaAP">
-			<var name="webContentContent"><![CDATA[<script>alert("web content article")</script>]]></var>
+			<var name="webContentContent"><![CDATA[<script>alert(123);</script>]]></var>
 			<var name="webContentTitle" value="WC WebContent Title" />
 		</execute>
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 	</command>
 </definition>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/businessproductivity/kaleoforms/usecase/KaleoFormsXSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/businessproductivity/kaleoforms/usecase/KaleoFormsXSS.testcase
@@ -91,12 +91,9 @@
 		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
 		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
-		<var name="key_rowEntry" value="alert" />
-
-		<execute function="Click" locator1="Icon#ROW_VERTICAL_ELLIPSIS" />
-
-		<execute function="AssertClick" locator1="MenuItem#ANY_MENU_ITEM" value1="Choose">
-			<var name="key_menuItem" value="Choose" />
+		<execute macro="LexiconEntry#gotoEntryMenuItem">
+			<var name="menuItem" value="Choose" />
+			<var name="rowEntry" value="alert" />
 		</execute>
 
 		<execute macro="KaleoFormsAdmin#next" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/businessproductivity/kaleoforms/usecase/KaleoFormsXSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduseree/businessproductivity/kaleoforms/usecase/KaleoFormsXSS.testcase
@@ -17,7 +17,7 @@
 
 		<execute macro="Workflow#uploadDefinition">
 			<var name="workflowDefinitionFile" value="workflow_definition_xss.xml" />
-			<var name="workflowDefinitionTitle"><![CDATA['alert(0)'"alert(0)"><img src=x onerror=alert(0)><script>alert(0)</script>]]></var>
+			<var name="workflowDefinitionTitle"><![CDATA[<script>alert(123);</script>]]></var>
 		</execute>
 
 		<execute macro="Navigator#openURL" />
@@ -82,6 +82,14 @@
 		</execute>
 
 		<execute macro="KaleoFormsAdmin#next" />
+
+		<execute function="AssertAlertNotPresent" />
+
+		<var name="actualScript"><![CDATA[<script>alert(123);</script>]]></var>
+		<var name="escapedScript"><![CDATA[&lt;script&gt;alert(123);&lt;/script&gt;]]></var>
+
+		<execute function="AssertHTMLSourceTextNotPresent" value1="${actualScript}" />
+		<execute function="AssertHTMLSourceTextPresent" value1="${escapedScript}" />
 
 		<var name="key_rowEntry" value="alert" />
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-33598
https://issues.liferay.com/browse/LRQA-38034
https://issues.liferay.com/browse/LRQA-38417

@anthony-chu some more forward ports, thanks!  

A note on this pull: https://github.com/anthony-chu/liferay-portal/pull/409/commits/7c60d9920987a1a55b264e220def0f4ba4873ba4 is a bit experimental, as `LexiconEntry#gotoEntryMenuItemNoError` uses `Click#waitForMenuToggleJSClick`, but the ones I've consolidated in that commit are all simple `Click` usages.  I'm thinking they can probably _all_ be ok running this line:
```
<execute argument1="//script[contains(@src,'/o/frontend-js-web/liferay/menu_toggle.js')]" selenium="waitForElementPresent" />
```

But we may want to see the initial CI results to make sure.  If it won't work, we can move all of those macro changes over to a _new_ LexiconEntry macro that would use the simple `Click` function.

I intentionally consolidated the ones in https://github.com/anthony-chu/liferay-portal/pull/409/commits/632be59e2e43e53afbe471dbcadfe2a83df2cc41 separately because they're using the same click function (`Click#waitForMenuToggleJSClick`), so this change should be safe.  I wanted to make it easy to revert or update any problematic macros.  Let me know what you think!

One more change of note is in both https://github.com/anthony-chu/liferay-portal/pull/409/commits/9af472eb0df208b95558683b0389d4f72d5b51e5 and https://github.com/anthony-chu/liferay-portal/pull/409/commits/1da6a8905e8095ad768b4c40d0a65d0bf18abf48 - this can probably be applied across more of the AP macros, but I wanted to start with the more exact versions instead of embarking on major reconstructive surgery :)

At any rate, it'll be good to see the test results and start from there.  Thanks!