### PR TITLE
LRQA-42156 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/LayoutPageTemplates.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/LayoutPageTemplates.macro
@@ -168,6 +168,7 @@
 		</execute>
 
 		<execute function="Click" locator1="Fragment#FRAGMENT_SIDEBAR_FRAGMENT">
+			<var name="key_collectionName" value="${collectionName}" />
 			<var name="key_fragmentName" value="${fragmentName}" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/fragments/Fragment.path
@@ -46,7 +46,7 @@
 </tr>
 <tr>
 	<td>FRAGMENT_SIDEBAR_FRAGMENT</td>
-	<td>//ul[contains(@class,'nav')]//div[contains(@id,'fragment-collection')]//button[@data-fragment-entry-name='${key_fragmentName}']</td>
+	<td>//ul[contains(@class,'nav')]//li[contains(.,'${key_collectionName}')]//button[@data-item-name='${key_fragmentName}']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42156
Tested Here: [#68](https://github.com/kyle-miho/liferay-portal/pull/68)
Backport to 7.1.x.
The Content option not being an option is a testfix thats already filed, and the other one (navigate before full page load) is also already filed somewhere else. The main fix is fixed.