### PR TITLE
LRQA-42011 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitelocalization/usecase/SitelocalizationUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitelocalization/usecase/SitelocalizationUsecase.testcase
@@ -768,6 +768,10 @@
 		</execute>
 
 		<execute macro="SitePages#addPublicPage">
+			<var name="pageName" value="Dummy Page" />
+		</execute>
+
+		<execute macro="SitePages#addPublicPage">
 			<var name="hideFromNavMenu" value="true" />
 			<var name="pageName" value="Language Page" />
 		</execute>


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-42011
Tested here: [#69](https://github.com/kyle-miho/liferay-portal/pull/69)
Backport to 7.1.x.
Fails due to a bug with localization right now, already reported. Dummy page was created to allow us to hide a page from the navigation menu (can't do it with the first) and creating a dummy page is less risky to break compared to removing the item manually from the navigation menu portlet.